### PR TITLE
fix: revert - use only lifetime begindate in indentifiers

### DIFF
--- a/src/MunicipalityRegistry/Municipality/Commands/Crab/ImportMunicipalityFromCrab.cs
+++ b/src/MunicipalityRegistry/Municipality/Commands/Crab/ImportMunicipalityFromCrab.cs
@@ -64,7 +64,7 @@ namespace MunicipalityRegistry.Municipality.Commands.Crab
             yield return SecondaryLanguage;
             yield return FacilityLanguage;
             yield return Geometry;
-            yield return Lifetime.BeginDateTime.Print();
+            yield return Lifetime;
             yield return Timestamp;
             yield return Operator;
             yield return Modification;

--- a/src/MunicipalityRegistry/Municipality/Commands/Crab/ImportMunicipalityNameFromCrab.cs
+++ b/src/MunicipalityRegistry/Municipality/Commands/Crab/ImportMunicipalityNameFromCrab.cs
@@ -44,13 +44,13 @@ namespace MunicipalityRegistry.Municipality.Commands.Crab
             => Deterministic.Create(Namespace, $"ImportMunicipalityNameFromCrab-{ToString()}");
 
         public override string ToString() =>
-            ToStringBuilder.ToString(IdentityFields);
+            ToStringBuilder.ToString(IdentityFields());
 
         private IEnumerable<object> IdentityFields()
         {
             yield return MunicipalityId;
             yield return MunicipalityName;
-            yield return Lifetime.BeginDateTime.Print();
+            yield return Lifetime;
             yield return Timestamp;
             yield return Operator;
             yield return Modification;


### PR DESCRIPTION
This reverts commit f53a15274f76bca90f669be03e50951db867149e.

failing test indiacted removing data from ToString is not the write way to remove LifeTime.Enddate from the hash.

revert fixes test, implement correct way monday